### PR TITLE
Feature/allow babel config overrides

### DIFF
--- a/packages/babel-preset-react-app/index.js
+++ b/packages/babel-preset-react-app/index.js
@@ -1,3 +1,10 @@
+// ****************************************************************************
+// IMPORTANT
+// This file is no longer used as `packages/react-scripts/config/webpack.config.*.js`
+// has been updated not to use `babel-preset-react-app`, but to instead use a
+// `.babelrc` config that contains the equivalent configuration.
+// ****************************************************************************
+
 /**
  * Copyright (c) 2015-present, Facebook, Inc.
  *

--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -165,8 +165,8 @@ module.exports = {
             loader: require.resolve('babel-loader'),
             options: {
               // @remove-on-eject-begin
-              babelrc: false,
-              presets: [require.resolve('babel-preset-react-app')],
+              babelrc: true,
+              presets: [],
               // @remove-on-eject-end
               // This is a feature of `babel-loader` for webpack (not Babel itself).
               // It enables caching results in ./node_modules/.cache/babel-loader/

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -168,8 +168,8 @@ module.exports = {
             loader: require.resolve('babel-loader'),
             options: {
               // @remove-on-eject-begin
-              babelrc: false,
-              presets: [require.resolve('babel-preset-react-app')],
+              babelrc: true,
+              presets: [],
               // @remove-on-eject-end
               compact: true,
             },

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babylon-react-scripts",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "description": "Configuration and scripts for Create React App.",
   "repository": "facebookincubator/create-react-app",
   "license": "MIT",

--- a/packages/react-scripts/template/src/.babelrc
+++ b/packages/react-scripts/template/src/.babelrc
@@ -46,7 +46,17 @@
           "env",
           {
             "targets": {
-              "ie": "9",
+              "browsers": [
+                "last 2 chrome versions",
+                "last 2 firefox versions",
+                "last 2 edge versions",
+                "last 2 safari versions",
+                "last 1 ie version",
+                "last 2 and_chr versions",
+                "last 2 ios_saf versions",
+                "last 2 ie_mob versions",
+                "> 3%"
+              ],
               "uglify": true
             },
             "useBuiltIns": false,
@@ -68,7 +78,17 @@
           "env",
           {
             "targets": {
-              "ie": "9",
+              "browsers": [
+                "last 2 chrome versions",
+                "last 2 firefox versions",
+                "last 2 edge versions",
+                "last 2 safari versions",
+                "last 1 ie version",
+                "last 2 and_chr versions",
+                "last 2 ios_saf versions",
+                "last 2 ie_mob versions",
+                "> 3%"
+              ],
               "uglify": true
             },
             "useBuiltIns": false,

--- a/packages/react-scripts/template/src/.babelrc
+++ b/packages/react-scripts/template/src/.babelrc
@@ -1,0 +1,82 @@
+{
+  "plugins": [
+    "transform-class-properties",
+    ["transform-object-rest-spread", {
+      "useBuiltIns": true
+    }],
+    ["transform-react-jsx", {
+      "useBuiltIns": true
+    }],
+    ["transform-runtime", {
+      "helpers": false,
+      "polyfill": false,
+      "regenerator": true
+    }]
+  ],
+  "env": {
+    "test": {
+      "plugins": [
+        "transform-react-jsx-source",
+        "transform-react-jsx-self",
+        "dynamic-import-node"
+      ],
+      "presets": [
+        [
+          "env",
+          {
+            "targets": {
+              "node": "current"
+            }
+          }
+        ],
+        "react"
+      ]
+    },
+    "development": {
+      "plugins": [
+        "transform-react-jsx-source",
+        "transform-react-jsx-self",
+        ["transform-regenerator", {
+          "async": false
+        }],
+        "syntax-dynamic-import"
+      ],
+      "presets": [
+        [
+          "env",
+          {
+            "targets": {
+              "ie": "9",
+              "uglify": true
+            },
+            "useBuiltIns": false,
+            "modules": false
+          }
+        ],
+        "react"
+      ]
+    },
+    "production": {
+      "plugins": [
+        ["transform-regenerator", {
+          "async": false
+        }],
+        "syntax-dynamic-import"
+      ],
+      "presets": [
+        [
+          "env",
+          {
+            "targets": {
+              "ie": "9",
+              "uglify": true
+            },
+            "useBuiltIns": false,
+            "modules": false
+          }
+        ],
+        "react"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Projects now specify their own `.babelrc` configurations, where the default started life as an exact replica of the old `packages/babel-preset-react-app/index.js` config file.

I subsequently updated the supported browsers to implement a sensible policy for Babylon. This ensures we're able to support the following:

  1. The last 2 versions of evergreen browsers on both desktop & mobile (i.e. Chrome, Firefox, Safari & Edge).
  2. IE11.
  3. Any other browser with significant market share (e.g. Opera Mobile & UC Browser for Android, which both have `> 3%` market share).