### PR TITLE
Add ES6 minification support

### DIFF
--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -12,6 +12,7 @@ const autoprefixer = require('autoprefixer');
 const path = require('path');
 const webpack = require('webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
+const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const ManifestPlugin = require('webpack-manifest-plugin');
 const InterpolateHtmlPlugin = require('react-dev-utils/InterpolateHtmlPlugin');
@@ -301,21 +302,28 @@ module.exports = {
     // Otherwise React will be compiled in the very slow development mode.
     new webpack.DefinePlugin(env.stringified),
     // Minify the code.
-    new webpack.optimize.UglifyJsPlugin({
-      compress: {
-        warnings: false,
-        // Disabled because of an issue with Uglify breaking seemingly valid code:
-        // https://github.com/facebookincubator/create-react-app/issues/2376
-        // Pending further investigation:
-        // https://github.com/mishoo/UglifyJS2/issues/2011
-        comparisons: false,
+    new UglifyJsPlugin({
+      uglifyOptions: {
+        compress: {
+          warnings: false,
+          // Disabled because of an issue with Uglify breaking seemingly valid code:
+          // https://github.com/facebookincubator/create-react-app/issues/2376
+          // Pending further investigation:
+          // https://github.com/mishoo/UglifyJS2/issues/2011
+          comparisons: false,
+        },
+        output: {
+          comments: false,
+          // Turned on because emoji and regex is not minified properly using default
+          // https://github.com/facebookincubator/create-react-app/issues/2488
+          ascii_only: true,
+        },
       },
-      output: {
-        comments: false,
-        // Turned on because emoji and regex is not minified properly using default
-        // https://github.com/facebookincubator/create-react-app/issues/2488
-        ascii_only: true,
-      },
+      // Use multi-process parallel running to improve the build speed
+      // Default number of concurrent runs: os.cpus().length - 1
+      parallel: true,
+      // Enable file caching
+      cache: true,
       sourceMap: shouldUseSourceMap,
     }),
     // Note: this won't work without ExtractTextPlugin.extract(..) in `loaders`.

--- a/packages/react-scripts/package-lock.json
+++ b/packages/react-scripts/package-lock.json
@@ -1,0 +1,726 @@
+{
+  "name": "babylon-react-scripts",
+  "version": "1.0.18",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "ajv": {
+      "version": "5.5.2",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/ajv/-/ajv-5.5.2.tgz",
+      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+      "dev": true,
+      "requires": {
+        "co": "4.6.0",
+        "fast-deep-equal": "1.0.0",
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.3.1"
+      }
+    },
+    "ajv-keywords": {
+      "version": "2.1.1",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
+      "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
+      "dev": true
+    },
+    "aproba": {
+      "version": "1.2.0",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/aproba/-/aproba-1.2.0.tgz",
+      "integrity": "sha1-aALmJk79GMeQobDVF/DyYnvyyUo=",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "bluebird": {
+      "version": "3.5.1",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/bluebird/-/bluebird-3.5.1.tgz",
+      "integrity": "sha1-2VUfnemPH82h5oPRfukaBgLuLrk=",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.8",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/brace-expansion/-/brace-expansion-1.1.8.tgz",
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "dev": true,
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "cacache": {
+      "version": "10.0.2",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/cacache/-/cacache-10.0.2.tgz",
+      "integrity": "sha1-EFqToWK77fOiXaQuGTntmf+xRfg=",
+      "dev": true,
+      "requires": {
+        "bluebird": "3.5.1",
+        "chownr": "1.0.1",
+        "glob": "7.1.2",
+        "graceful-fs": "4.1.11",
+        "lru-cache": "4.1.1",
+        "mississippi": "1.3.0",
+        "mkdirp": "0.5.1",
+        "move-concurrently": "1.0.1",
+        "promise-inflight": "1.0.1",
+        "rimraf": "2.6.2",
+        "ssri": "5.0.0",
+        "unique-filename": "1.1.0",
+        "y18n": "3.2.1"
+      }
+    },
+    "chownr": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/chownr/-/chownr-1.0.1.tgz",
+      "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
+      "dev": true
+    },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "dev": true
+    },
+    "commander": {
+      "version": "2.13.0",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/commander/-/commander-2.13.0.tgz",
+      "integrity": "sha1-aWS8pnaF33wfFDDFhPB9dZeIW5w=",
+      "dev": true
+    },
+    "commondir": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "concat-stream": {
+      "version": "1.6.0",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/concat-stream/-/concat-stream-1.6.0.tgz",
+      "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3",
+        "typedarray": "0.0.6"
+      }
+    },
+    "copy-concurrently": {
+      "version": "1.0.5",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
+      "integrity": "sha1-kilzmMrjSTf8r9bsgTnBgFHwteA=",
+      "dev": true,
+      "requires": {
+        "aproba": "1.2.0",
+        "fs-write-stream-atomic": "1.0.10",
+        "iferr": "0.1.5",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.2",
+        "run-queue": "1.0.3"
+      }
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
+    "cyclist": {
+      "version": "0.2.2",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/cyclist/-/cyclist-0.2.2.tgz",
+      "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
+      "dev": true
+    },
+    "duplexify": {
+      "version": "3.5.3",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/duplexify/-/duplexify-3.5.3.tgz",
+      "integrity": "sha1-i1gYgA35L9ASWyeriWSRkShYJD4=",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "1.4.1",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3",
+        "stream-shift": "1.0.0"
+      }
+    },
+    "end-of-stream": {
+      "version": "1.4.1",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/end-of-stream/-/end-of-stream-1.4.1.tgz",
+      "integrity": "sha1-7SljTRm6ukY7bOa4CjchPqtx7EM=",
+      "dev": true,
+      "requires": {
+        "once": "1.4.0"
+      }
+    },
+    "errno": {
+      "version": "0.1.6",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/errno/-/errno-0.1.6.tgz",
+      "integrity": "sha1-w4bOimKD8U/AlWO3FWCQjJv1MCY=",
+      "dev": true,
+      "requires": {
+        "prr": "1.0.1"
+      }
+    },
+    "fast-deep-equal": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
+      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "dev": true
+    },
+    "find-cache-dir": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
+      "integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
+      "dev": true,
+      "requires": {
+        "commondir": "1.0.1",
+        "make-dir": "1.1.0",
+        "pkg-dir": "2.0.0"
+      }
+    },
+    "find-up": {
+      "version": "2.1.0",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/find-up/-/find-up-2.1.0.tgz",
+      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+      "dev": true,
+      "requires": {
+        "locate-path": "2.0.0"
+      }
+    },
+    "flush-write-stream": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/flush-write-stream/-/flush-write-stream-1.0.2.tgz",
+      "integrity": "sha1-yBuQ2HRnZvGmCaRoCZRsRd2K5Bc=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3"
+      }
+    },
+    "from2": {
+      "version": "2.3.0",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/from2/-/from2-2.3.0.tgz",
+      "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3"
+      }
+    },
+    "fs-write-stream-atomic": {
+      "version": "1.0.10",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
+      "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "iferr": "0.1.5",
+        "imurmurhash": "0.1.4",
+        "readable-stream": "2.3.3"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.1.11",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+      "dev": true
+    },
+    "iferr": {
+      "version": "0.1.5",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/iferr/-/iferr-0.1.5.tgz",
+      "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
+      "dev": true
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "json-schema-traverse": {
+      "version": "0.3.1",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+      "dev": true
+    },
+    "locate-path": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/locate-path/-/locate-path-2.0.0.tgz",
+      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+      "dev": true,
+      "requires": {
+        "p-locate": "2.0.0",
+        "path-exists": "3.0.0"
+      }
+    },
+    "lru-cache": {
+      "version": "4.1.1",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/lru-cache/-/lru-cache-4.1.1.tgz",
+      "integrity": "sha1-Yi4y6CSItJJ5EUpPns9F581rulU=",
+      "dev": true,
+      "requires": {
+        "pseudomap": "1.0.2",
+        "yallist": "2.1.2"
+      }
+    },
+    "make-dir": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/make-dir/-/make-dir-1.1.0.tgz",
+      "integrity": "sha1-GbQ2n+SMEW9Twq+VrRAsDjnoXVE=",
+      "dev": true,
+      "requires": {
+        "pify": "3.0.0"
+      }
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "1.1.8"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "mississippi": {
+      "version": "1.3.0",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/mississippi/-/mississippi-1.3.0.tgz",
+      "integrity": "sha1-0gFYPrEjJ+PFwWQqQEqcrPlONPU=",
+      "dev": true,
+      "requires": {
+        "concat-stream": "1.6.0",
+        "duplexify": "3.5.3",
+        "end-of-stream": "1.4.1",
+        "flush-write-stream": "1.0.2",
+        "from2": "2.3.0",
+        "parallel-transform": "1.1.0",
+        "pump": "1.0.3",
+        "pumpify": "1.4.0",
+        "stream-each": "1.2.2",
+        "through2": "2.0.3"
+      }
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "move-concurrently": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/move-concurrently/-/move-concurrently-1.0.1.tgz",
+      "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
+      "dev": true,
+      "requires": {
+        "aproba": "1.2.0",
+        "copy-concurrently": "1.0.5",
+        "fs-write-stream-atomic": "1.0.10",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.2",
+        "run-queue": "1.0.3"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
+    "p-limit": {
+      "version": "1.2.0",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/p-limit/-/p-limit-1.2.0.tgz",
+      "integrity": "sha1-DpK2vty1nwIsE9DxlJ3ILRWQnxw=",
+      "dev": true,
+      "requires": {
+        "p-try": "1.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/p-locate/-/p-locate-2.0.0.tgz",
+      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "dev": true,
+      "requires": {
+        "p-limit": "1.2.0"
+      }
+    },
+    "p-try": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/p-try/-/p-try-1.0.0.tgz",
+      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+      "dev": true
+    },
+    "parallel-transform": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/parallel-transform/-/parallel-transform-1.1.0.tgz",
+      "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
+      "dev": true,
+      "requires": {
+        "cyclist": "0.2.2",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3"
+      }
+    },
+    "path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "dev": true
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "pify": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+      "dev": true
+    },
+    "pkg-dir": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/pkg-dir/-/pkg-dir-2.0.0.tgz",
+      "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+      "dev": true,
+      "requires": {
+        "find-up": "2.1.0"
+      }
+    },
+    "process-nextick-args": {
+      "version": "1.0.7",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+      "dev": true
+    },
+    "promise-inflight": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/promise-inflight/-/promise-inflight-1.0.1.tgz",
+      "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
+      "dev": true
+    },
+    "prr": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/prr/-/prr-1.0.1.tgz",
+      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
+      "dev": true
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "dev": true
+    },
+    "pump": {
+      "version": "1.0.3",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/pump/-/pump-1.0.3.tgz",
+      "integrity": "sha1-Xf6DEcM7v2/BgmH580cCxHwIqVQ=",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "1.4.1",
+        "once": "1.4.0"
+      }
+    },
+    "pumpify": {
+      "version": "1.4.0",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/pumpify/-/pumpify-1.4.0.tgz",
+      "integrity": "sha1-gLfF334kFT0D8OesigWl0Gi9B/s=",
+      "dev": true,
+      "requires": {
+        "duplexify": "3.5.3",
+        "inherits": "2.0.3",
+        "pump": "2.0.0"
+      },
+      "dependencies": {
+        "pump": {
+          "version": "2.0.0",
+          "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/pump/-/pump-2.0.0.tgz",
+          "integrity": "sha1-eUbaHI1iKwmOLOstNHZYJHCCnJ0=",
+          "dev": true,
+          "requires": {
+            "end-of-stream": "1.4.1",
+            "once": "1.4.0"
+          }
+        }
+      }
+    },
+    "readable-stream": {
+      "version": "2.3.3",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/readable-stream/-/readable-stream-2.3.3.tgz",
+      "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
+      "dev": true,
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "1.0.7",
+        "safe-buffer": "5.1.1",
+        "string_decoder": "1.0.3",
+        "util-deprecate": "1.0.2"
+      }
+    },
+    "rimraf": {
+      "version": "2.6.2",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha1-LtgVDSShbqhlHm1u8PR8QVjOejY=",
+      "dev": true,
+      "requires": {
+        "glob": "7.1.2"
+      }
+    },
+    "run-queue": {
+      "version": "1.0.3",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/run-queue/-/run-queue-1.0.3.tgz",
+      "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
+      "dev": true,
+      "requires": {
+        "aproba": "1.2.0"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.1",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM=",
+      "dev": true
+    },
+    "schema-utils": {
+      "version": "0.4.3",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/schema-utils/-/schema-utils-0.4.3.tgz",
+      "integrity": "sha1-4qWU0zlYNNXhXaIrSL4TUXhZRY4=",
+      "dev": true,
+      "requires": {
+        "ajv": "5.5.2",
+        "ajv-keywords": "2.1.1"
+      }
+    },
+    "serialize-javascript": {
+      "version": "1.4.0",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/serialize-javascript/-/serialize-javascript-1.4.0.tgz",
+      "integrity": "sha1-fJWFFNtqwkQ6irwGLcn3iGp/YAU=",
+      "dev": true
+    },
+    "source-list-map": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/source-list-map/-/source-list-map-2.0.0.tgz",
+      "integrity": "sha1-qqR0A/eyRakvvJfqCPJQ1gh+0IU=",
+      "dev": true
+    },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+      "dev": true
+    },
+    "ssri": {
+      "version": "5.0.0",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/ssri/-/ssri-5.0.0.tgz",
+      "integrity": "sha1-E8GTkLYGyCHyoQ0Cs1HBcpuU2M8=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "stream-each": {
+      "version": "1.2.2",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/stream-each/-/stream-each-1.2.2.tgz",
+      "integrity": "sha1-joxGP5HaiZF3h2WHP+TZYNj2Fr0=",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "1.4.1",
+        "stream-shift": "1.0.0"
+      }
+    },
+    "stream-shift": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/stream-shift/-/stream-shift-1.0.0.tgz",
+      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
+      "dev": true
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "through2": {
+      "version": "2.0.3",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/through2/-/through2-2.0.3.tgz",
+      "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "2.3.3",
+        "xtend": "4.0.1"
+      }
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
+    "uglify-es": {
+      "version": "3.3.7",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/uglify-es/-/uglify-es-3.3.7.tgz",
+      "integrity": "sha1-0SSa9mhmarp8sRY+J3RVvp6zk88=",
+      "dev": true,
+      "requires": {
+        "commander": "2.13.0",
+        "source-map": "0.6.1"
+      }
+    },
+    "uglifyjs-webpack-plugin": {
+      "version": "1.1.6",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.1.6.tgz",
+      "integrity": "sha1-9LqESe3PF4NcGLpq6ZudYQhX+xk=",
+      "dev": true,
+      "requires": {
+        "cacache": "10.0.2",
+        "find-cache-dir": "1.0.0",
+        "schema-utils": "0.4.3",
+        "serialize-javascript": "1.4.0",
+        "source-map": "0.6.1",
+        "uglify-es": "3.3.7",
+        "webpack-sources": "1.1.0",
+        "worker-farm": "1.5.2"
+      }
+    },
+    "unique-filename": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/unique-filename/-/unique-filename-1.1.0.tgz",
+      "integrity": "sha1-0F8v5AMlYIcfMOk8vnNe6iAVFPM=",
+      "dev": true,
+      "requires": {
+        "unique-slug": "2.0.0"
+      }
+    },
+    "unique-slug": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/unique-slug/-/unique-slug-2.0.0.tgz",
+      "integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
+      "dev": true,
+      "requires": {
+        "imurmurhash": "0.1.4"
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "webpack-sources": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/webpack-sources/-/webpack-sources-1.1.0.tgz",
+      "integrity": "sha1-oQHrrlnWUHNU1x2AE5UKOot6WlQ=",
+      "dev": true,
+      "requires": {
+        "source-list-map": "2.0.0",
+        "source-map": "0.6.1"
+      }
+    },
+    "worker-farm": {
+      "version": "1.5.2",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/worker-farm/-/worker-farm-1.5.2.tgz",
+      "integrity": "sha1-MrMS5dw9XUXXnvRKzCWHSRzXKa4=",
+      "dev": true,
+      "requires": {
+        "errno": "0.1.6",
+        "xtend": "4.0.1"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "xtend": {
+      "version": "4.0.1",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+      "dev": true
+    },
+    "y18n": {
+      "version": "3.2.1",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/y18n/-/y18n-3.2.1.tgz",
+      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+      "dev": true
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://artifactory.ops.babylontech.co.uk/artifactory/api/npm/babylon-virtual-npm/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "dev": true
+    }
+  }
+}

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babylon-react-scripts",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "description": "Configuration and scripts for Create React App.",
   "repository": "facebookincubator/create-react-app",
   "license": "MIT",
@@ -57,6 +57,7 @@
     "sass-loader": "^6.0.6",
     "style-loader": "0.18.2",
     "sw-precache-webpack-plugin": "0.11.4",
+    "uglifyjs-webpack-plugin": "^1.1.6",
     "url-loader": "0.5.9",
     "webpack": "3.5.1",
     "webpack-dev-server": "2.8.2",


### PR DESCRIPTION
We previously made a change to allow projects to define their own `.babelrc`, but this wasn't especially useful since if you stopped emitting ES5 then `npm run build` stopped working.