### PR TITLE
 Make CSS Module classes test friendly

### DIFF
--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -211,7 +211,8 @@ module.exports = {
                 options: {
                   importLoaders: 1,
                   modules: true,
-                  localIdentName: '[name]__[local]___[hash:base64:5]',
+                  localIdentRegExp: /.*\/([^/]+)\/src/,
+                  localIdentName: '[1]__[folder]__[local]',
                 },
               },
               {

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -234,7 +234,8 @@ module.exports = {
                         minimize: true,
                         sourceMap: true,
                         modules: true,
-                        localIdentName: '[name]__[local]___[hash:base64:5]',
+                        localIdentRegExp: /.*\/([^/]+)\/src/,
+                        localIdentName: '[1]__[folder]__[local]',
                       },
                     },
                     {

--- a/packages/react-scripts/package-lock.json
+++ b/packages/react-scripts/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "babylon-react-scripts",
-  "version": "1.0.24",
+  "version": "1.0.25",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babylon-react-scripts",
-  "version": "1.0.24",
+  "version": "1.0.25",
   "description": "Configuration and scripts for Create React App.",
   "repository": "facebookincubator/create-react-app",
   "license": "MIT",


### PR DESCRIPTION
It's impossible to write CSS selectors against class names that contain random hashses, so use a friendlier naming scheme that's still able to minimize the risk of a name clash occuring.

For example:

```
.babylon-component-library__Textarea__label {
  color: red;
}
```