### PR TITLE
Use a custom getLocalIdent name so that we generate classNames with the required behaviour

### DIFF
--- a/packages/react-scripts/config/getLocalIdent.js
+++ b/packages/react-scripts/config/getLocalIdent.js
@@ -16,19 +16,19 @@ const getLocalIdent = (context, localIdentName, localName) => {
     pathInsideSrc.split('/').slice(-2, -1)[0] :
     context.resourcePath.split('/').slice(-2, -1)[0];
 
-  const moduleName =
+  const fileName =
     pathInsideSrc
       .split('/')
       .slice(-1)[0]
       .split('.')[0] || ''
 
-  let finalisedFolderName =
-    moduleName.startsWith('index') ||
-    moduleName.startsWith('styles')
+  let moduleName =
+    fileName.startsWith('index') ||
+    fileName.startsWith('styles')
       ? parentFolderName
-      : moduleName;
+      : fileName;
 
-  return `${projectName}__${finalisedFolderName}__${localName}`;
+  return `${projectName}__${moduleName}__${localName}`;
 }
 
 module.exports = getLocalIdent

--- a/packages/react-scripts/config/getLocalIdent.js
+++ b/packages/react-scripts/config/getLocalIdent.js
@@ -1,0 +1,34 @@
+'use strict'
+
+const getLocalIdent = (context, localIdentName, localName) => {
+  const projectNameMatches = /.*\/([^/]+)\/src|lib\/([^/]+)/.exec(
+    context.resourcePath
+  ) || []
+
+  const projectName =
+    projectNameMatches[2] || projectNameMatches[1] || 'babylon'
+
+  const pathInsideSrc = context.resourcePath.split(
+    new RegExp(`${projectName}/(?:src/)?`, 'g')
+  )[1] || context.resourcePath
+
+  const parentFolderName = pathInsideSrc ?
+    pathInsideSrc.split('/').slice(-2, -1)[0] :
+    context.resourcePath.split('/').slice(-2, -1)[0]
+
+  const moduleName =
+    pathInsideSrc
+      .split('/')
+      .slice(-1)[0]
+      .split('.')[0] || ''
+
+  let finalisedFolderName =
+    moduleName.startsWith('index') ||
+    moduleName.startsWith('styles')
+      ? parentFolderName
+      : moduleName
+
+  return `${projectName}__${finalisedFolderName}__${localName}`
+}
+
+module.exports = getLocalIdent

--- a/packages/react-scripts/config/getLocalIdent.js
+++ b/packages/react-scripts/config/getLocalIdent.js
@@ -3,18 +3,18 @@
 const getLocalIdent = (context, localIdentName, localName) => {
   const projectNameMatches = /.*\/([^/]+)\/src|lib\/([^/]+)/.exec(
     context.resourcePath
-  ) || []
+  ) || [];
 
   const projectName =
-    projectNameMatches[2] || projectNameMatches[1] || 'babylon'
+    projectNameMatches[2] || projectNameMatches[1] || 'babylon';
 
   const pathInsideSrc = context.resourcePath.split(
     new RegExp(`${projectName}/(?:src/)?`, 'g')
-  )[1] || context.resourcePath
+  )[1] || context.resourcePath;
 
   const parentFolderName = pathInsideSrc ?
     pathInsideSrc.split('/').slice(-2, -1)[0] :
-    context.resourcePath.split('/').slice(-2, -1)[0]
+    context.resourcePath.split('/').slice(-2, -1)[0];
 
   const moduleName =
     pathInsideSrc
@@ -26,9 +26,9 @@ const getLocalIdent = (context, localIdentName, localName) => {
     moduleName.startsWith('index') ||
     moduleName.startsWith('styles')
       ? parentFolderName
-      : moduleName
+      : moduleName;
 
-  return `${projectName}__${finalisedFolderName}__${localName}`
+  return `${projectName}__${finalisedFolderName}__${localName}`;
 }
 
 module.exports = getLocalIdent

--- a/packages/react-scripts/config/getLocalIdent.js
+++ b/packages/react-scripts/config/getLocalIdent.js
@@ -23,10 +23,9 @@ const getLocalIdent = (context, localIdentName, localName) => {
       .split('.')[0] || ''
 
   let moduleName =
-    fileName.startsWith('index') ||
-    fileName.startsWith('styles')
-      ? parentFolderName
-      : fileName;
+    /^[A-Z]/.test(fileName)
+      ? fileName
+      : parentFolderName;
 
   return `${projectName}__${moduleName}__${localName}`;
 }

--- a/packages/react-scripts/config/getLocalIdent.spec.js
+++ b/packages/react-scripts/config/getLocalIdent.spec.js
@@ -9,56 +9,56 @@ describe('getLocalIdent', () => {
       resourcePath: '/foo/example-project/src/components/Test/Test.module.scss'
     }, null, 'exampleClass')
 
-    expect(output).toEqual('example-project__Test__exampleClass')
+    expect(output).toEqual('example-project__Test__exampleClass');
   })
 
   it('should use the folder name for files named "index" or "styles"', () => {
     const output1 = getLocalIdent({
       resourcePath: '/foo/example-project/src/components/Test/index.module.scss'
-    }, null, 'exampleClass')
+    }, null, 'exampleClass');
 
     const output2 = getLocalIdent({
       resourcePath: '/foo/example-project/src/components/Test/styles.module.scss'
-    }, null, 'exampleClass')
+    }, null, 'exampleClass');
 
-    expect(output1).toEqual('example-project__Test__exampleClass')
-    expect(output2).toEqual('example-project__Test__exampleClass')
+    expect(output1).toEqual('example-project__Test__exampleClass');
+    expect(output2).toEqual('example-project__Test__exampleClass');
   })
 
   it('should also resolve the project name from a "lib" folder without a src', () => {
     const output = getLocalIdent({
       resourcePath: '../../../lib/example-lib/Test/Test.module.scss'
-    }, null, 'exampleClass')
+    }, null, 'exampleClass');
 
-    expect(output).toEqual('example-lib__Test__exampleClass')
+    expect(output).toEqual('example-lib__Test__exampleClass');
   })
 
   it('should also resolve the project name from a "lib" folder with a src folder', () => {
     const output = getLocalIdent({
       resourcePath: '../../../lib/example-lib/src/Test/Test.module.scss'
-    }, null, 'exampleClass')
+    }, null, 'exampleClass');
 
-    expect(output).toEqual('example-lib__Test__exampleClass')
+    expect(output).toEqual('example-lib__Test__exampleClass');
   })
 
   it('should default to "babylon" if there is no matching src or lib folder', () => {
     const output = getLocalIdent({
       resourcePath: '../../../example-project/RandomFolder/Test.module.scss'
-    }, null, 'exampleClass')
+    }, null, 'exampleClass');
 
-    expect(output).toEqual('babylon__Test__exampleClass')
+    expect(output).toEqual('babylon__Test__exampleClass');
   })
 
   it('should default to "babylon" and the folder name if there is no matching src or lib folder and the file is named index or styles', () => {
     const output1 = getLocalIdent({
       resourcePath: '../../../example-project/RandomFolder/index.module.scss'
-    }, null, 'exampleClass')
+    }, null, 'exampleClass');
 
     const output2 = getLocalIdent({
       resourcePath: '../../../example-project/RandomFolder/styles.module.scss'
-    }, null, 'exampleClass')
+    }, null, 'exampleClass');
 
-    expect(output1).toEqual('babylon__RandomFolder__exampleClass')
-    expect(output2).toEqual('babylon__RandomFolder__exampleClass')
+    expect(output1).toEqual('babylon__RandomFolder__exampleClass');
+    expect(output2).toEqual('babylon__RandomFolder__exampleClass');
   })
 })

--- a/packages/react-scripts/config/getLocalIdent.spec.js
+++ b/packages/react-scripts/config/getLocalIdent.spec.js
@@ -1,0 +1,64 @@
+/* globals describe, it, expect */
+'use strict'
+
+const getLocalIdent = require('./getLocalIdent.js')
+
+describe('getLocalIdent', () => {
+  it('should use the module name for files not named "index" or "styles"', () => {
+    const output = getLocalIdent({
+      resourcePath: '/foo/example-project/src/components/Test/Test.module.scss'
+    }, null, 'exampleClass')
+
+    expect(output).toEqual('example-project__Test__exampleClass')
+  })
+
+  it('should use the folder name for files named "index" or "styles"', () => {
+    const output1 = getLocalIdent({
+      resourcePath: '/foo/example-project/src/components/Test/index.module.scss'
+    }, null, 'exampleClass')
+
+    const output2 = getLocalIdent({
+      resourcePath: '/foo/example-project/src/components/Test/styles.module.scss'
+    }, null, 'exampleClass')
+
+    expect(output1).toEqual('example-project__Test__exampleClass')
+    expect(output2).toEqual('example-project__Test__exampleClass')
+  })
+
+  it('should also resolve the project name from a "lib" folder without a src', () => {
+    const output = getLocalIdent({
+      resourcePath: '../../../lib/example-lib/Test/Test.module.scss'
+    }, null, 'exampleClass')
+
+    expect(output).toEqual('example-lib__Test__exampleClass')
+  })
+
+  it('should also resolve the project name from a "lib" folder with a src folder', () => {
+    const output = getLocalIdent({
+      resourcePath: '../../../lib/example-lib/src/Test/Test.module.scss'
+    }, null, 'exampleClass')
+
+    expect(output).toEqual('example-lib__Test__exampleClass')
+  })
+
+  it('should default to "babylon" if there is no matching src or lib folder', () => {
+    const output = getLocalIdent({
+      resourcePath: '../../../example-project/RandomFolder/Test.module.scss'
+    }, null, 'exampleClass')
+
+    expect(output).toEqual('babylon__Test__exampleClass')
+  })
+
+  it('should default to "babylon" and the folder name if there is no matching src or lib folder and the file is named index or styles', () => {
+    const output1 = getLocalIdent({
+      resourcePath: '../../../example-project/RandomFolder/index.module.scss'
+    }, null, 'exampleClass')
+
+    const output2 = getLocalIdent({
+      resourcePath: '../../../example-project/RandomFolder/styles.module.scss'
+    }, null, 'exampleClass')
+
+    expect(output1).toEqual('babylon__RandomFolder__exampleClass')
+    expect(output2).toEqual('babylon__RandomFolder__exampleClass')
+  })
+})

--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -212,8 +212,6 @@ module.exports = {
                 options: {
                   importLoaders: 1,
                   modules: true,
-                  localIdentRegExp: /.*\/([^/]+)\/src/,
-                  localIdentName: '[1]__[folder]__[local]',
                   getLocalIdent
                 },
               },

--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -18,6 +18,7 @@ const WatchMissingNodeModulesPlugin = require('react-dev-utils/WatchMissingNodeM
 const ModuleScopePlugin = require('react-dev-utils/ModuleScopePlugin');
 const getClientEnvironment = require('./env');
 const paths = require('./paths');
+const getLocalIdent = require('./getLocalIdent');
 
 // Options for PostCSS as we reference these options twice
 // Adds vendor prefixing to support IE9 and above
@@ -213,6 +214,7 @@ module.exports = {
                   modules: true,
                   localIdentRegExp: /.*\/([^/]+)\/src/,
                   localIdentName: '[1]__[folder]__[local]',
+                  getLocalIdent
                 },
               },
               {

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -235,8 +235,6 @@ module.exports = {
                         minimize: true,
                         sourceMap: true,
                         modules: true,
-                        localIdentRegExp: /.*\/([^/]+)\/src/,
-                        localIdentName: '[1]__[folder]__[local]',
                         getLocalIdent,
                       },
                     },

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -20,6 +20,7 @@ const SWPrecacheWebpackPlugin = require('sw-precache-webpack-plugin');
 const ModuleScopePlugin = require('react-dev-utils/ModuleScopePlugin');
 const paths = require('./paths');
 const getClientEnvironment = require('./env');
+const getLocalIdent = require('./getLocalIdent');
 
 // Webpack uses `publicPath` to determine where the app is being served from.
 // It requires a trailing slash, or the file assets will get an incorrect path.
@@ -236,6 +237,7 @@ module.exports = {
                         modules: true,
                         localIdentRegExp: /.*\/([^/]+)\/src/,
                         localIdentName: '[1]__[folder]__[local]',
+                        getLocalIdent,
                       },
                     },
                     {


### PR DESCRIPTION
See the `getLocalIdent.spec.js` file for the behaviour. But basically:

`example-project/src/components/Foo/Bar.module.scss` => `example-project__Bar__exampleClass`
`example-project/src/components/Foo/styles.module.scss` => `example-project__Foo__exampleClass`
`example-project/src/components/Foo/index.module.scss` => `example-project__Foo__exampleClass`
`../lib/magic-lib/src/Components/Foo/index.module.scss` => `magic-lib__Foo__exampleClass`
`../lib/magic-lib/src/Components/Foo/Bar.module.scss` => `magic-lib__Bar__exampleClass`