### PR TITLE
Add webpack plugin to extract envVars during compilation so we know w…

### DIFF
--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -57,6 +57,46 @@ if (env.stringified['process.env'].NODE_ENV !== '"production"') {
   throw new Error('Production builds must have NODE_ENV=production.');
 }
 
+class ExtractEnvVarsPlugin {
+  constructor(options) {
+    this.vars = []
+  }
+
+  apply(compiler) {
+    const vars = this.vars
+
+    compiler.hooks.compilation.tap('ExtractEnvVarsPlugin', (compilation) => {
+      compilation.hooks.optimizeChunks.tap('ExtractEnvVarsPlugin', chunks => {
+        chunks.forEach(chunk => {
+          const modules = Array.from(chunk._modules)
+          modules.forEach(module => {
+            if (module._source && module._source._value && /\.js$/.test(module.resource)) {
+              const content = fs.readFileSync(module.resource).toString()
+              const envVars = []
+              const regExp = /env(?:Flag|Url|Var)\(\s*["']([A-Z0-9_]+)["']/g
+              let match = null
+
+              while ((match = regExp.exec(content)) !== null) {
+                if (vars.indexOf(match[1]) < 0) {
+                  vars.push(match[1])
+                }
+              }
+            }
+          })
+        })
+      })
+    })
+
+    compiler.hooks.emit.tapAsync('ExtractEnvVarsPlugin', (compilation, callback) => {
+      compilation.assets['envVars'] = {
+        source: () => this.vars.join('\n'),
+        size: () => this.vars.length
+      }
+      callback()
+    })
+  }
+}
+
 // Check if TypeScript is setup
 const useTypeScript = fs.existsSync(paths.appTsConfig);
 
@@ -532,6 +572,8 @@ module.exports = {
         new RegExp('/[^/]+\\.[^/]+$'),
       ],
     }),
+    // Extract environment variables for babylon-env
+    new ExtractEnvVarsPlugin(),
     // TypeScript type checking
     fs.existsSync(paths.appTsConfig) &&
     new ForkTsCheckerWebpackPlugin({

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -62,26 +62,30 @@ class ExtractEnvVarsPlugin {
     this.vars = []
   }
 
-  apply(compiler) {
-    const vars = this.vars
+  shouldProcessModule(module) {
+    return module._source && module._source._value && /\.js$/.test(module.resource)
+  }
 
+  findMatchesInFile(fileContent) {
+    const vars = this.vars
+    const regExp = /env(?:Flag|Url|Var)\(\s*["']([A-Z0-9_]+)["']/g
+    let match = null
+
+    while ((match = regExp.exec(fileContent)) !== null) {
+      if (vars.indexOf(match[1]) < 0) {
+        vars.push(match[1])
+      }
+    }
+  }
+
+  apply(compiler) {
     compiler.hooks.compilation.tap('ExtractEnvVarsPlugin', (compilation) => {
       compilation.hooks.optimizeChunks.tap('ExtractEnvVarsPlugin', chunks => {
         chunks.forEach(chunk => {
           const modules = Array.from(chunk._modules)
-          modules.forEach(module => {
-            if (module._source && module._source._value && /\.js$/.test(module.resource)) {
-              const content = fs.readFileSync(module.resource).toString()
-              const envVars = []
-              const regExp = /env(?:Flag|Url|Var)\(\s*["']([A-Z0-9_]+)["']/g
-              let match = null
-
-              while ((match = regExp.exec(content)) !== null) {
-                if (vars.indexOf(match[1]) < 0) {
-                  vars.push(match[1])
-                }
-              }
-            }
+          modules.filter(this.shouldProcessModule).forEach(module => {
+            const content = fs.readFileSync(module.resource).toString()
+            this.findMatchesInFile(content)
           })
         })
       })


### PR DESCRIPTION
Extracts the env vars that we need into a `envVars` file in the build folder, which we can then use in in `inject-env-vars` to pass in the required values.