### PR TITLE
Extract env vars from ts/tsx files

### DIFF
--- a/packages/react-scripts/config/ExtractEnvVarsPlugin.js
+++ b/packages/react-scripts/config/ExtractEnvVarsPlugin.js
@@ -9,7 +9,9 @@ class ExtractEnvVarsPlugin {
 
   shouldProcessModule(module) {
     return (
-      module._source && module._source._value && /\.js$/.test(module.resource)
+      module._source &&
+      module._source._value &&
+      /\.(j|t)sx?$/.test(module.resource)
     );
   }
 

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@babylon/react-scripts",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Configuration and scripts for Create React App.",
   "repository": "facebook/create-react-app",
   "license": "MIT",


### PR DESCRIPTION
Jira ticket: https://babylonpartners.atlassian.net/browse/MOP-173

When running `react-scripts build` the plugin to extract envVars did not include looking in `.ts` and `.tsx` files. This PR fixes this.